### PR TITLE
Parse Webhook でメールアドレスの取得方法を修正

### DIFF
--- a/src/SendGrid.Webhooks/Internal/HttpRequestExtension.cs
+++ b/src/SendGrid.Webhooks/Internal/HttpRequestExtension.cs
@@ -17,7 +17,7 @@ namespace SendGrid.Webhooks.Internal
             return (request.Unvalidated(key) ?? "").Split(separator);
         }
 
-        public static double AsInt(this HttpRequestBase request, string key)
+        public static int AsInt(this HttpRequestBase request, string key)
         {
             int result;
 

--- a/src/SendGrid.Webhooks/Parse/ParseModelBinder.cs
+++ b/src/SendGrid.Webhooks/Parse/ParseModelBinder.cs
@@ -36,7 +36,8 @@ namespace SendGrid.Webhooks.Parse
 
         private static readonly Regex[] _mailAddressPattern =
         {
-            new Regex(@"^(.+) <(.+)>$", RegexOptions.Compiled | RegexOptions.ECMAScript)
+            new Regex(@"^(?<name>.+) <(?<address>.+)>$", RegexOptions.Compiled | RegexOptions.ECMAScript),
+            new Regex(@"^<(?<address>.+)>$", RegexOptions.Compiled | RegexOptions.ECMAScript)
         };
 
         private static MailAddress ParseMailAddress(string mailAddress)
@@ -58,8 +59,8 @@ namespace SendGrid.Webhooks.Parse
 
             return new MailAddress
             {
-                Name = match.Groups[1].Value,
-                Address = match.Groups[2].Value
+                Name = match.Groups["name"].Value,
+                Address = match.Groups["address"].Value
             };
         }
 


### PR DESCRIPTION
Parse Webhook でメールアドレスを取得する際に、どちらの形式にも対応しました。
名前 ＜xxx@example.com＞
＜xxx@example.com＞
